### PR TITLE
Fix eslint warnings in time tracking components

### DIFF
--- a/resources/js/components/time-tracking/time-entry-form.tsx
+++ b/resources/js/components/time-tracking/time-entry-form.tsx
@@ -103,7 +103,7 @@ export function TimeEntryForm({
         setTaskId(null);
       }
     }
-  }, [projectId, tasks]);
+  }, [projectId, taskId, tasks]);
   
   // Set billable default based on category selection
   useEffect(() => {

--- a/resources/js/pages/TimeTracking/Reports.tsx
+++ b/resources/js/pages/TimeTracking/Reports.tsx
@@ -74,7 +74,7 @@ export default function TimeTrackingReports({
     value: periodValue
   });
   
-  const fetchReportData = async () => {
+  const fetchReportData = useCallback(async () => {
     setLoading(true);
     
     try {
@@ -91,11 +91,11 @@ export default function TimeTrackingReports({
     } finally {
       setLoading(false);
     }
-  };
-  
+  }, [period]);
+
   useEffect(() => {
     fetchReportData();
-  }, [period]);
+  }, [fetchReportData]);
   
   const handlePreviousPeriod = () => {
     if (period.type === 'month') {


### PR DESCRIPTION
## Summary
- add missing dependencies to `useEffect` hooks
- memoize report fetch call with `useCallback`

## Testing
- `npm run lint`
- `php artisan test` *(fails: Database connection error)*
