### PR TITLE
Añadir integración Docker CI/CD (Dockerfile, GH Actions, docs)

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,61 @@
+name: Build & Release Docker image
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set image tag
+        id: vars
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "tag=ghcr.io/${{ github.repository }}:pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=ghcr.io/${{ github.repository }}:latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.vars.outputs.tag }}
+          platforms: linux/amd64,linux/arm64
+
+      - name: Create GitHub Release
+        if: github.event_name == 'push'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: release-${{ github.sha }}
+          name: release-${{ github.sha }}
+          body: |
+            Docker image tag: ${{ steps.vars.outputs.tag }}
+          files: docs/docker.md
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+- Add Docker containerization with multi-arch build using Laravel Octane and Swoole.
+- CI/CD pipeline builds and publishes Docker images to GHCR on push to `main` and pull requests.
+- Documentation added in `docs/docker.md` describing Docker usage and Kubernetes deployment.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+# Stage 1: build frontend assets using Node 22
+FROM node:22-alpine AS node-build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY resources ./resources
+COPY vite.config.ts tsconfig.json ./
+RUN npm run build
+
+# Stage 2: install PHP dependencies
+FROM composer:2.9-php8.3-alpine AS vendor
+WORKDIR /app
+COPY composer.json composer.lock ./
+RUN composer install --no-dev --optimize-autoloader
+
+# Stage 3: production runtime with Octane
+FROM php:8.3-cli-alpine AS runtime
+# Install PHP extensions and Swoole
+RUN apk add --no-cache --virtual .build-deps $PHPIZE_DEPS icu-dev zlib-dev libzip-dev libpng-dev libjpeg-turbo-dev freetype-dev oniguruma-dev postgresql-dev git \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j$(nproc) pdo_mysql pdo_pgsql bcmath intl gd opcache \
+    && pecl install swoole \
+    && docker-php-ext-enable swoole \
+    && apk del .build-deps
+
+ENV APP_ENV=production \ 
+    APP_DEBUG=false \ 
+    OCTANE_SERVER=swoole
+
+# Create application directory and user
+WORKDIR /var/www/html
+RUN addgroup -S laravel && adduser -S laravel -G laravel
+
+# Copy dependencies and code
+COPY --from=vendor /app/vendor ./vendor
+COPY --from=node-build /app/public ./public
+COPY app app
+COPY bootstrap bootstrap
+COPY config config
+COPY database database
+COPY public/index.php public/index.php
+COPY storage storage
+COPY resources/views resources/views
+COPY routes routes
+COPY artisan .
+COPY composer.json composer.lock ./
+
+# Optimize and set permissions
+RUN php artisan storage:link && \
+    php artisan config:cache && \
+    php artisan route:cache && \
+    php artisan view:cache && \
+    chown -R laravel:laravel storage bootstrap/cache
+
+USER laravel
+EXPOSE 8000
+CMD ["php","artisan","octane:start","--server=swoole","--host=0.0.0.0","--port=8000"]

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,79 @@
+# Docker Guide
+
+## Prerequisites
+- Docker 25 or newer
+- `GHCR_TOKEN` (or `GITHUB_TOKEN`) for pushing images to GHCR
+- PHP 8.3 CLI and Node LTS installed
+
+## Local Development with Octane
+1. `composer install`
+2. `npm ci`
+3. `php artisan octane:start --watch`
+
+## Docker Development
+```yaml
+dev-app:
+  build: .
+  volumes:
+    - .:/var/www/html
+  ports:
+    - "8000:8000"
+```
+Using SQLite for quick tests:
+```bash
+docker run -e DB_CONNECTION=sqlite -e APP_KEY=base64:YOURKEY -p 8000:8000 ghcr.io/your/image:latest
+```
+
+## Understanding Tenancy
+- Central DB via `DB_*` variables
+- Tenants use databases resolved by `stancl/tenancy`
+- Run central and tenant migrations separately.
+  For subdomain testing locally, edit `/etc/hosts` to map tenant domains
+  (e.g. `tenant.localhost`).
+
+## Deploying to Kubernetes
+Use the image from GHCR in a Deployment:
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: enkiflow
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: enkiflow
+  template:
+    metadata:
+      labels:
+        app: enkiflow
+    spec:
+      containers:
+        - name: app
+          image: ghcr.io/your/image:latest
+          env:
+            - name: APP_KEY
+              value: your-key
+            - name: DB_CONNECTION
+              value: pgsql
+          ports:
+            - containerPort: 8000
+```
+Configure `TENANCY_DOMAIN_BASE` to match the wildcard domain set in your Ingress.
+
+## CI Flow
+GitHub Actions builds multi-arch images on every push.
+`main` publishes the `latest` tag, while pull requests receive a
+`pr-<number>` tag for preview. Each release includes this document
+as an asset for quick reference.
+
+## Production Run
+Pull the image from GHCR and run behind Nginx or Traefik.
+Use Octane signals to reload without downtime.
+
+## FAQ
+- Ensure `APP_KEY` is set in production.
+- Adjust file permissions for `storage` and `bootstrap/cache` if needed.
+- Monitor Swoole for memory leaks.
+- Tweak `--max-requests` and DB pool size based on load.
+- SSL termination should happen at the proxy layer.


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile for production with Octane
- extend workflow to build/push Docker images on push and PR
- document Docker usage and deployment
- start changelog

## Testing
- `composer install --no-interaction --prefer-dist`
- `pnpm install --frozen-lockfile` *(failed: lockfile missing)*
- `npm ci`
- `composer test` *(failed: 82 failed tests)*
