### PR TITLE
ci(docker): migrate release workflow to Docker Hub & add Scout verification

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -15,6 +15,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      IMAGE_NAME: c0305/enkiflow
+      IMAGE_TAG: ${{ github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || 'latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -25,29 +28,28 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GHCR
+      - name: Log in to Docker Hub
+        # Remember to create DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets in Settings → Secrets → Actions
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set image tag
-        id: vars
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "tag=ghcr.io/${{ github.repository }}:pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=ghcr.io/${{ github.repository }}:latest" >> "$GITHUB_OUTPUT"
-          fi
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push image
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
-          tags: ${{ steps.vars.outputs.tag }}
+          tags: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
           platforms: linux/amd64,linux/arm64
+
+      - name: Verify Laravel Scout
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          docker run --rm -e APP_ENV=testing -e SCOUT_DRIVER=database \
+            ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} \
+            php artisan scout:index --pretend
 
       - name: Create GitHub Release
         if: github.event_name == 'push'
@@ -56,6 +58,6 @@ jobs:
           tag_name: release-${{ github.sha }}
           name: release-${{ github.sha }}
           body: |
-            Docker image tag: ${{ steps.vars.outputs.tag }}
+            Docker image tag: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
           files: docs/docker.md
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ herd restart php
 
 # Check available PHP versions in Herd
 herd php:list
+
+# Push the Docker image to Docker Hub
+./scripts/push-image.sh $(git rev-parse --short HEAD)
 ```
 
 ### Common macOS Issues

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,8 +1,14 @@
 # Docker Guide
 
+The official image is published on **Docker Hub** and can be pulled with:
+
+```bash
+docker pull c0305/enkiflow:latest
+```
+
 ## Prerequisites
 - Docker 25 or newer
-- `GHCR_TOKEN` (or `GITHUB_TOKEN`) for pushing images to GHCR
+- `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` for pushing images to Docker Hub
 - PHP 8.3 CLI and Node LTS installed
 
 ## Local Development with Octane
@@ -21,7 +27,7 @@ dev-app:
 ```
 Using SQLite for quick tests:
 ```bash
-docker run -e DB_CONNECTION=sqlite -e APP_KEY=base64:YOURKEY -p 8000:8000 ghcr.io/your/image:latest
+docker run -e DB_CONNECTION=sqlite -e APP_KEY=base64:YOURKEY -p 8000:8000 c0305/enkiflow:latest
 ```
 
 ## Understanding Tenancy
@@ -32,7 +38,7 @@ docker run -e DB_CONNECTION=sqlite -e APP_KEY=base64:YOURKEY -p 8000:8000 ghcr.i
   (e.g. `tenant.localhost`).
 
 ## Deploying to Kubernetes
-Use the image from GHCR in a Deployment:
+Use the image from Docker Hub in a Deployment:
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -50,7 +56,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: ghcr.io/your/image:latest
+          image: c0305/enkiflow:latest
           env:
             - name: APP_KEY
               value: your-key
@@ -62,13 +68,15 @@ spec:
 Configure `TENANCY_DOMAIN_BASE` to match the wildcard domain set in your Ingress.
 
 ## CI Flow
-GitHub Actions builds multi-arch images on every push.
+GitHub Actions builds multi-arch images on every push and publishes them to **Docker Hub**.
 `main` publishes the `latest` tag, while pull requests receive a
-`pr-<number>` tag for preview. Each release includes this document
+`pr-<number>` tag for preview. After pushing, the workflow runs
+`php artisan scout:index --pretend` inside the new container to ensure
+Laravel Scout initializes correctly. Each release includes this document
 as an asset for quick reference.
 
 ## Production Run
-Pull the image from GHCR and run behind Nginx or Traefik.
+Pull the image from Docker Hub and run behind Nginx or Traefik.
 Use Octane signals to reload without downtime.
 
 ## FAQ

--- a/scripts/push-image.sh
+++ b/scripts/push-image.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IMAGE_NAME="c0305/enkiflow"
+IMAGE_TAG="${1:-local}"
+docker buildx build --platform linux/amd64,linux/arm64 -t "$IMAGE_NAME:$IMAGE_TAG" --push .
+


### PR DESCRIPTION
## Summary
- push Docker images to Docker Hub instead of GHCR
- verify Laravel Scout after building the image
- add helper script to push images locally
- document Docker Hub usage and new script

## Testing
- `composer install --no-interaction --prefer-dist`
- `pnpm install --frozen-lockfile` *(failed: no lockfile)*
- `npm ci`
- `php artisan test` *(failed: 82 failed, database connection issues)*